### PR TITLE
Conditionally enable comments based on post date

### DIFF
--- a/build.js
+++ b/build.js
@@ -71,6 +71,31 @@ async function generatePost(metadata, htmlContent) {
         // Generate canonical URL - add trailing slash
         const canonicalUrl = `${siteMetadata.siteUrl}/posts/${metadata.slug}/`;
 
+        // Determine if we should show giscus comments based on post date
+        const postDate = new Date(metadata.date);
+        const cutoffDate = new Date('2015-01-01');
+        const showGiscus = postDate >= cutoffDate;
+
+        // Generate comments section HTML
+        const commentsHtml = showGiscus ? `
+        <section class="comments">
+            <script src="https://giscus.app/client.js"
+                data-repo="jkpe/www.jackpearce.co.uk-comments"
+                data-repo-id="R_kgDOLfwvdA"
+                data-category="Announcements"
+                data-category-id="DIC_kwDOLfwvdM4Cd8Ni"
+                data-mapping="title"
+                data-strict="0"
+                data-reactions-enabled="1"
+                data-emit-metadata="0"
+                data-input-position="bottom"
+                data-theme="preferred_color_scheme"
+                data-lang="en"
+                crossorigin="anonymous"
+                async>
+            </script>
+        </section>` : '';
+
         // Replace template variables
         const replacements = {
             '{{title}}': metadata.title,
@@ -80,7 +105,9 @@ async function generatePost(metadata, htmlContent) {
             '{{readTime}}': metadata.readTime,
             '{{content}}': htmlContent,
             '<meta rel="canonical" href="https://www.jackpearce.co.uk">': 
-                `<meta rel="canonical" href="${canonicalUrl}">`
+                `<meta rel="canonical" href="${canonicalUrl}">`,
+            '<section class="comments">': commentsHtml ? commentsHtml : '<!-- giscus comments disabled for older posts -->',
+            '</section>': commentsHtml ? '</section>' : ''
         };
 
         // Replace all occurrences of each template variable

--- a/templates/post.html
+++ b/templates/post.html
@@ -406,21 +406,6 @@
         </main>
         
         <section class="comments">
-            <script src="https://giscus.app/client.js"
-                data-repo="jkpe/www.jackpearce.co.uk-comments"
-                data-repo-id="R_kgDOLfwvdA"
-                data-category="Announcements"
-                data-category-id="DIC_kwDOLfwvdM4Cd8Ni"
-                data-mapping="title"
-                data-strict="0"
-                data-reactions-enabled="1"
-                data-emit-metadata="0"
-                data-input-position="bottom"
-                data-theme="preferred_color_scheme"
-                data-lang="en"
-                crossorigin="anonymous"
-                async>
-            </script>
         </section>
 
         <footer class="footer">


### PR DESCRIPTION
## Summary
- Add conditional logic to only show giscus comments on posts published after January 1, 2015
- Move comments section from template to dynamically generated HTML
- Add placeholder comment for older posts where comments are disabled

## Test plan
- Build site and check that recent posts have comments section
- Verify older posts (pre-2015) do not display giscus comments

🤖 Generated with [Claude Code](https://claude.ai/code)